### PR TITLE
Integrate SHAP visualizations into Streamlit dashboard

### DIFF
--- a/dashboard/streamlit_dashboard.py
+++ b/dashboard/streamlit_dashboard.py
@@ -440,6 +440,49 @@ def about_page():
     </div>
     """, unsafe_allow_html=True)
 
+
+def render_shap_visualizations():
+    """Render SHAP visualizations from the artifacts directory"""
+    st.header("SHAP Model Explanations")
+    st.markdown("""
+    This section displays various SHAP (SHapley Additive exPlanations) visualizations
+    to help understand model behavior and feature contributions. These plots are typically
+    generated after model training and explanation.
+
+    *If you don't see any visualizations, please ensure the model explanation script
+    (`src/credit_default/components/model_explain_test.py`) has been run successfully
+    and that visualizations are present in the `artifacts/explainer/shap_visualizations/` directory.*
+    """)
+
+    viz_dir = Path("artifacts/explainer/shap_visualizations/")
+
+    if not viz_dir.exists() or not viz_dir.is_dir():
+        st.warning(f"Visualization directory not found: {viz_dir.resolve()}")
+        st.info("Please run the model explanation script to generate visualizations.")
+        return
+
+    viz_files = sorted(list(viz_dir.glob("*.png")) + list(viz_dir.glob("*.html")))
+
+    if not viz_files:
+        st.info(f"No visualizations found in {viz_dir.resolve()}.")
+        return
+
+    for viz_file in viz_files:
+        st.subheader(f"Displaying: {viz_file.name}")
+        try:
+            if viz_file.suffix == ".png":
+                st.image(str(viz_file), use_column_width=True)
+            elif viz_file.suffix == ".html":
+                with open(viz_file, 'r', encoding='utf-8') as f:
+                    html_content = f.read()
+                # Adjust height based on typical SHAP plot needs
+                height = 400 if "force_plot" in viz_file.name else 800
+                st.components.v1.html(html_content, height=height, scrolling=True)
+            st.markdown("---")
+        except Exception as e:
+            st.error(f"Could not display {viz_file.name}: {e}")
+
+
 def main():
     """Main application"""
     # Title and description
@@ -455,7 +498,7 @@ def main():
     st.sidebar.title("Navigation")
     page = st.sidebar.selectbox(
         "Choose a page",
-        ["Single Prediction", "Batch Prediction", "Model Analytics", "About"]
+        ["Single Prediction", "Batch Prediction", "Model Analytics", "SHAP Visualizations", "About"]
     )
 
     # Load pipeline
@@ -551,6 +594,9 @@ def main():
     elif page == "Model Analytics":
         render_model_analytics()
     
+    elif page == "SHAP Visualizations":
+        render_shap_visualizations()
+
     elif page == "About":
         about_page()
 

--- a/src/credit_default/components/model_explain_test.py
+++ b/src/credit_default/components/model_explain_test.py
@@ -23,21 +23,22 @@ class ModelExplainer:
     def __init__(self, 
                  model_path: str,
                  test_data_path: str,
-                 visualization_dir: str):
+                 visualization_dir: str = "artifacts/explainer/shap_visualizations/"):
         """
         Initialize ModelExplainer
         
         Args:
             model_path: Path to the trained model
             test_data_path: Path to test data
-            visualization_dir: Directory to save visualizations
+            visualization_dir: Directory to save visualizations. Defaults to "artifacts/explainer/shap_visualizations/".
         """
         self.model_path = model_path
         self.test_data_path = test_data_path
-        self.visualization_dir = visualization_dir
+        # Ensure visualization_dir is a Path object and project-relative
+        self.visualization_dir = Path(visualization_dir)
         
-        # Create visualization directory
-        os.makedirs(self.visualization_dir, exist_ok=True)
+        # Create visualization directory if it doesn't exist
+        self.visualization_dir.mkdir(parents=True, exist_ok=True)
         
         # Initialize components
         self.model = None
@@ -605,16 +606,24 @@ class ModelExplainer:
 if __name__ == "__main__":
     try:
         # Example usage
-        model_path = "C:\\Users\\hp\\Desktop\\credit card\\credit_default_prediction_complete\\credit_default_prediction\\artifacts\\model_trainer\\best_model.pkl"
-        test_data_path = "C:\\Users\\hp\\Desktop\\credit card\\credit_default_prediction_complete\\credit_default_prediction\\artifacts\\data_transformation\\test.csv"
-        visualization_dir = "C:\\Users\\hp\\Desktop\\credit card\\credit_default_prediction_complete\\credit_default_prediction\\artifacts\\explainer\\new_output"
+        # Define project root dynamically for better portability
+        PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
+        model_path = PROJECT_ROOT / "artifacts" / "model_trainer" / "best_model.pkl"
+        test_data_path = PROJECT_ROOT / "artifacts" / "data_transformation" / "test.csv"
+        # visualization_dir will use the default "artifacts/explainer/shap_visualizations/"
+
+        # Ensure model and test data paths are strings if required by underlying libraries
         explainer = ModelExplainer(
-            model_path=model_path,
-            test_data_path=test_data_path,
-            visualization_dir=visualization_dir
+            model_path=str(model_path),
+            test_data_path=str(test_data_path)
+            # visualization_dir uses default
         )
         
+        logging.info(f"Attempting to load model from: {model_path}")
+        logging.info(f"Attempting to load test data from: {test_data_path}")
+        logging.info(f"Visualizations will be saved to: {explainer.visualization_dir.resolve()}")
+
         # Generate all visualizations
         summary_stats = explainer.generate_all_visualizations()
         


### PR DESCRIPTION
- Renamed model_expain_test.py to model_explain_test.py.
- Standardized visualization output path in model_explain_test.py to 'artifacts/explainer/shap_visualizations/'.
- Added a new 'SHAP Visualizations' page to the Streamlit dashboard.
- Implemented functionality to load and display PNG and HTML SHAP plots from the standardized directory on this new page.